### PR TITLE
vkontakte.ru -> vk.com

### DIFF
--- a/src/social-likes.js
+++ b/src/social-likes.js
@@ -64,7 +64,7 @@ var services = {
 		popupHeight: 360
 	},
 	vkontakte: {
-		counterUrl: 'http://vkontakte.ru/share.php?act=count&url={url}&index={index}',
+		counterUrl: 'http://vk.com/share.php?act=count&url={url}&index={index}',
 		counter: function(jsonUrl, deferred) {
 			var options = services.vkontakte;
 			if (!options._) {


### PR DESCRIPTION
`vkontakte.ru/share.php` redirects to `vk.com/login` which redirects to `vk.com/share.php`

Both with 301 status (Moved Permanently). 
