### PR TITLE
Place language switcher on top of ‘fork me’

### DIFF
--- a/styles/styles.styl
+++ b/styles/styles.styl
@@ -4,6 +4,7 @@
 	position:absolute;
 	top:15px;
 	right:2*spacer;
+	z-index: 1000;
 }
 
 .description {


### PR DESCRIPTION
Now sometimes when you try to click the language switcher link, it won’t let you because the ‘fork me’ ribbon is partly overlapping it.