### PR TITLE
plusone - use protocol-relative URL for counter (works on both http & https)

### DIFF
--- a/src/social-likes.js
+++ b/src/social-likes.js
@@ -114,7 +114,7 @@
 		},
 		plusone: {
 			// HTTPS not supported yet: http://clubs.ya.ru/share/1499
-			counterUrl: isHttps ? undefined : 'http://share.yandex.ru/gpp.xml?url={url}',
+			counterUrl: '//share.yandex.ru/gpp.xml?url={url}',
 			counter: function(jsonUrl, deferred) {
 				var options = services.plusone;
 				if (options._) {


### PR DESCRIPTION
Artem, I've updated plusone counter URL so that it works for both http and https pages - let me know if that's OK. (otherwise plusone does not show likes count on https pages)

