### PR TITLE
Remove plusone counter

### DIFF
--- a/src/social-likes.js
+++ b/src/social-likes.js
@@ -114,10 +114,7 @@
 			popupHeight: 336,
 		},
 		plusone: {
-			counterUrl: protocol + '//share.yandex.ru/gpp.xml?url={url}&callback=?',
-			convertNumber: function(number) {
-				return parseInt(number.replace(/\D/g, ''), 10);
-			},
+			counters: false,
 			popupUrl: 'https://plus.google.com/share?url={url}',
 			popupWidth: 500,
 			popupHeight: 550,


### PR DESCRIPTION
Google plus [turned off share counters](https://plus.google.com/110610523830483756510/posts/Z1FfzduveUo), so to get rid of 404 errors in console (like in issues #203 and #207), I removed plusone counter.
